### PR TITLE
Move model loading into main block

### DIFF
--- a/app.py
+++ b/app.py
@@ -167,7 +167,6 @@ def load_all_models():
                 model.load_state_dict(torch.load(model_path, map_location=device))
                 model.eval()
                 models_cache[(ticker, days)] = model
-load_all_models()
 
 @app.route('/')
 def index():
@@ -462,4 +461,5 @@ def delete_transaction(transaction_id):
     return redirect(url_for('profile'))
 
 if __name__ == '__main__':
+    load_all_models()
     app.run(debug=True)


### PR DESCRIPTION
## Summary
- ensure model loading happens when starting the server by moving `load_all_models()` under the `__main__` guard

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684aaef6f3088330b647537279f2d8a7