### PR TITLE
Отображение ошибок LSTM и GRU в прогнозах

### DIFF
--- a/app.py
+++ b/app.py
@@ -517,10 +517,13 @@ def predict():
         recommendation = "Держать"
 
     plot_html = render_template('partials/plot.html', plot_div=plot_div, error_plot_div=error_plot_div)
-    predictions_html = render_template('partials/predictions.html',
-                                       predictions=predictions,
-                                       backtest_predictions=backtest_predictions_lstm,
-                                       backtest_error=backtest_error_lstm)
+    predictions_html = render_template(
+        'partials/predictions.html',
+        predictions=predictions,
+        backtest_predictions=backtest_predictions_lstm,
+        backtest_error_lstm=backtest_error_lstm,
+        backtest_error_gru=backtest_error_gru,
+    )
 
     return jsonify({
         'plot_html': plot_html,

--- a/templates/partials/predictions.html
+++ b/templates/partials/predictions.html
@@ -1,5 +1,13 @@
 <div class="table-responsive">
-  <div class="alert alert-info">Ошибка на истории: MAE = {{ backtest_error.mae }}, RMSE = {{ backtest_error.rmse }}</div>
+  <div class="alert alert-info">
+    Ошибка LSTM: MAE = {{ backtest_error_lstm.mae }},
+    RMSE = {{ backtest_error_lstm.rmse }}
+    {% if backtest_error_gru.mae %}
+      <br>
+      Ошибка GRU: MAE = {{ backtest_error_gru.mae }},
+      RMSE = {{ backtest_error_gru.rmse }}
+    {% endif %}
+  </div>
   <table class="table table-sm table-dark align-middle mb-0 rounded-3 overflow-hidden">
     <thead class="bg-secondary bg-gradient text-light small">
       <tr>


### PR DESCRIPTION
## Summary
- передаем в шаблон ошибки backtest по LSTM и GRU
- выводим данные об ошибках обеих моделей в predictions.html

## Testing
- `python -m py_compile app.py`
- `python - <<'PY'
from jinja2 import Environment, FileSystemLoader
Environment(loader=FileSystemLoader('templates')).get_template('partials/predictions.html')
print('Jinja2 template loaded successfully')
PY`

------
https://chatgpt.com/codex/tasks/task_e_684b510693f48330a4eb1cbe5f20af50